### PR TITLE
Fix starting foremand in start_services.rb

### DIFF
--- a/rootfs/start_services.rb
+++ b/rootfs/start_services.rb
@@ -16,6 +16,6 @@ SERVICE_NAMES.each do |service_name|
   system("service #{service_name} start")
 end
 
-if SERVICE_NAMES.include?("foremand-supervisor")
+if SERVICE_NAMES.include?(:"foremand-supervisor")
   system("foremand start")
 end


### PR DESCRIPTION
SERVICES array hold :"foremand-supervisor" symbol not string.